### PR TITLE
Initial eigen3_cmake_module package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.5)
+project(eigen3_cmake_module)
+
+find_package(ament_cmake REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_lint_cmake)
+  find_package(ament_cmake_copyright)
+
+  # Find module is intentionally mixed case, so tell linter to ignore that
+  ament_lint_cmake("--filter=-convention/filename,-package/stdargs")
+  ament_copyright()
+endif()
+
+ament_package(
+  CONFIG_EXTRAS "eigen3_cmake_module-extras.cmake"
+)
+
+install(DIRECTORY cmake
+  DESTINATION share/${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ project(eigen3_cmake_module)
 find_package(ament_cmake REQUIRED)
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_lint_cmake)
-  find_package(ament_cmake_copyright)
+  find_package(ament_cmake_lint_cmake REQUIRED)
+  find_package(ament_cmake_copyright REQUIRED)
 
   # Find module is intentionally mixed case, so tell linter to ignore that
   ament_lint_cmake("--filter=-convention/filename,-package/stdargs")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+Any contribution that you make to this repository will
+be under the Apache 2 License, as dictated by that
+[license](http://www.apache.org/licenses/LICENSE-2.0.html):
+
+~~~
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+~~~
+
+Contributors must sign-off each commit by adding a `Signed-off-by: ...`
+line to commit messages to certify that they have the right to submit
+the code they are contributing to the project according to the
+[Developer Certificate of Origin (DCO)](https://developercertificate.org/).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eigen3_cmake_module
 
-This package adds a [CMake find module](https://cmake.org/cmake/help/v3.14/manual/cmake-developer.7.html#find-modulesjj) for [Eigen3](https://eigen.tuxfamily.org/dox/) that sets [standard cmake variables](https://cmake.org/cmake/help/v3.5/manual/cmake-developer.7.html#standard-variable-names).
+This package adds a [CMake find module](https://cmake.org/cmake/help/v3.14/manual/cmake-developer.7.html#find-modulesjj) for [Eigen3](https://eigen.tuxfamily.org/dox/) that sets [standard CMake variables](https://cmake.org/cmake/help/v3.5/manual/cmake-developer.7.html#standard-variable-names).
 This enables `ament_export_dependencies(Eigen3)` and `ament_target_dependencies(my_target Eigen3)`.
 
 ## Using this package

--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ If your package uses Eigen3 in public headers, then **also add** these tags so d
 <build_export_depend>eigen</build_export_depend>
 ```
 
-`<exec_depend>` are not necessary because `Eigen3` is a header only library.
+`<exec_depend>` is not necessary because `Eigen3` is a header only library.

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ Add a buildtool dependency to this package, and a build dependency to Eigen3 to 
 
 ```xml
 <buildtool_depend>eigen3_cmake_module</buildtool_depend>
-<build_depend>Eigen3</build_depend>
+<build_depend>eigen</build_depend>
 ```
 
 If your package uses Eigen3 in public headers, then **also add** these tags so downstream packages also depend on this package and `Eigen3`.
 
 ```xml
 <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
-<build_export_depend>Eigen3</build_export_depend>
+<build_export_depend>eigen</build_export_depend>
 ```
 
 `<exec_depend>` are not necessary because `Eigen3` is a header only library.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This enables `ament_export_dependencies(Eigen3)` and `ament_target_dependencies(
 
 ## Using this package
 
-This section assume you're using [ament_cmake](https://github.com/ament/ament_cmake).
+This section assumes you're using [ament_cmake](https://github.com/ament/ament_cmake).
 
 ### Edit your CMakeLists.txt
 In your `CMakeLists.txt`, call `find_package()` on this package using `REQUIRED`; then find `Eigen3`.
@@ -48,4 +48,4 @@ If your package uses Eigen3 in public headers, then **also add** these tags so d
 <build_export_depend>Eigen3</build_export_depend>
 ```
 
-`<run_depend>` are not necessary because `Eigen3` is a header only library.
+`<exec_depend>` are not necessary because `Eigen3` is a header only library.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
 # eigen3_cmake_module
-Adds a custom find module for Eigen3
+
+This package adds a [CMake find module](https://cmake.org/cmake/help/v3.14/manual/cmake-developer.7.html#find-modulesjj) for [Eigen3](https://eigen.tuxfamily.org/dox/) that sets [standard cmake variables](https://cmake.org/cmake/help/v3.5/manual/cmake-developer.7.html#standard-variable-names).
+This enables `ament_export_dependencies(Eigen3)` and `ament_target_dependencies(my_target Eigen3)`.
+
+## Using this package
+
+This section assume you're using [ament_cmake](https://github.com/ament/ament_cmake).
+
+### Edit your CMakeLists.txt
+In your `CMakeLists.txt`, call `find_package()` on this package using `REQUIRED`; then find `Eigen3`.
+
+```CMake
+find_package(eigen3_cmake_module REQUIRED)
+find_package(Eigen3)
+```
+
+If your library or executable uses `Eigen3`, then call `ament_target_dependencies()` to give it access to the `Eigen3` headers.
+
+```CMake
+# add_library(my_thing ...)
+# # OR
+# add_executable(my_thing ...)
+# ...
+ament_target_dependencies(my_thing Eigen3)
+```
+
+If your package uses Eigen3 in public headers, then call `ament_export_dependencies()` on this package, and afterwards do the same for `Eigen3`.
+
+```CMake
+ament_export_dependencies(eigen3_cmake_module)
+ament_export_dependencies(Eigen3)
+```
+
+### Edit your package.xml
+
+Add build dependencies to both this package and Eigen3 to your `package.xml`.
+
+```xml
+<build_depend>eigen3_cmake_module</build_depend>
+<build_depend>Eigen3</build_depend>
+```
+
+If your package uses Eigen3 in public headers, then **also add** `<build_export_depend>` so downstream packages depend on both this package and `Eigen3`.
+
+```xml
+<build_export_depend>eigen3_cmake_module</build_export_depend>
+<build_export_depend>Eigen3</build_export_depend>
+```
+
+`<run_depend>` are not necessary because `Eigen3` is a header only library.

--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ ament_export_dependencies(Eigen3)
 
 ### Edit your package.xml
 
-Add build dependencies to both this package and Eigen3 to your `package.xml`.
+Add a buildtool dependency to this package, and a build dependency to Eigen3 to your `package.xml`.
 
 ```xml
-<build_depend>eigen3_cmake_module</build_depend>
+<buildtool_depend>eigen3_cmake_module</buildtool_depend>
 <build_depend>Eigen3</build_depend>
 ```
 
-If your package uses Eigen3 in public headers, then **also add** `<build_export_depend>` so downstream packages depend on both this package and `Eigen3`.
+If your package uses Eigen3 in public headers, then **also add** these tags so downstream packages also depend on this package and `Eigen3`.
 
 ```xml
-<build_export_depend>eigen3_cmake_module</build_export_depend>
+<buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
 <build_export_depend>Eigen3</build_export_depend>
 ```
 

--- a/cmake/Modules/FindEigen3.cmake
+++ b/cmake/Modules/FindEigen3.cmake
@@ -1,0 +1,44 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This find_module finds Eigen3 and assigns variables to standard variable names
+# This allows the module to work with ament_export_dependencies
+
+include(FindPackageHandleStandardArgs)
+
+# Use Eigen3Config.cmake to do most of the work
+find_package(Eigen3 CONFIG)
+
+find_package_handle_standard_args(
+  Eigen3
+  VERSION_VAR
+    EIGEN3_VERSION_STRING
+  REQUIRED_VARS
+    EIGEN3_FOUND
+)
+if(EIGEN3_FOUND)
+  # Set standard variable names
+  # https://cmake.org/cmake/help/v3.5/manual/cmake-developer.7.html#standard-variable-names
+  set(_standard_vars
+    INCLUDE_DIRS
+    DEFINITIONS
+    ROOT_DIR)
+  foreach(_suffix ${_standard_vars})
+    set(_wrong_var "EIGEN3_${_suffix}")
+    set(_right_var "Eigen3_${_suffix}")
+    if(NOT DEFINED ${_right_var} AND DEFINED ${_wrong_var})
+      set(${_right_var} "${${_wrong_var}}")
+    endif()
+  endforeach()
+endif()

--- a/eigen3_cmake_module-extras.cmake
+++ b/eigen3_cmake_module-extras.cmake
@@ -1,0 +1,15 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+list(INSERT CMAKE_MODULE_PATH 0 "${eigen3_cmake_module_DIR}/Modules")

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>eigen3_cmake_module</name>
+  <version>0.1.0</version>
+  <description>Exports a custom CMake module to find Eigen3.</description>
+
+  <author email="sloretz@openrobotics.org">Shane Loretz</author>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_copyright</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/package.xml
+++ b/package.xml
@@ -11,8 +11,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
This adds a package that provides a find module for `Eigen3` that sets standard cmake variables.